### PR TITLE
Fix refspec - use correct env var name

### DIFF
--- a/main.go
+++ b/main.go
@@ -89,7 +89,7 @@ func main() {
 		cli.StringFlag{
 			Name:   "commit.refspec",
 			Usage:  "git commit ref spec",
-			EnvVar: "DRONE_COMMIT_REFSPEC",
+			EnvVar: "DRONE_COMMIT_REF",
 		},
 		cli.StringFlag{
 			Name:   "commit.branch",


### PR DESCRIPTION
It's `DRONE_COMMIT_REF` in both 0.8 and 1.0

https://0-8-0.docs.drone.io/environment-reference/
https://docs.drone.io/reference/environ/drone-commit-ref/