### PR TITLE
docs: update notification docs for Woodpecker 3.x status changes

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -197,3 +197,31 @@ urlencode
 
 since
 : returns a duration string between now and the given timestamp. Example `{{since build.started}}`
+
+## Note for Woodpecker 3.x Users
+
+Starting from Woodpecker 3.x, the `build.status` variable is always set to `success`, which means message templates cannot correctly distinguish between success and failure. It is recommended to use the `when.status` condition to split notifications for success and failure, as shown below:
+
+```yaml
+- name: discord success notification
+  when:
+    status: [ success ]
+  image: appleboy/drone-discord
+  settings:
+    webhook_id: xxxxxxxxxx
+    webhook_token: xxxxxxxxxx
+    message: >
+      build {{build.number}} succeeded. Good job.
+
+- name: discord failure notification
+  when:
+    status: [ failure ]
+  image: appleboy/drone-discord
+  settings:
+    webhook_id: xxxxxxxxxx
+    webhook_token: xxxxxxxxxx
+    message: >
+      build {{build.number}} failed. Fix me please.
+```
+
+This is due to a change in Woodpecker CI behavior and cannot be fixed on the plugin side. Please use the above workaround for correct notifications.

--- a/DOCS.md
+++ b/DOCS.md
@@ -200,7 +200,7 @@ since
 
 ## Note for Woodpecker 3.x Users
 
-Starting from Woodpecker 3.x, the `build.status` variable is always set to `success`, which means message templates cannot correctly distinguish between success and failure. It is recommended to use the `when.status` condition to split notifications for success and failure, as shown below:
+Starting with Woodpecker 3.x, the `build.status` variable is always set to `success`, which means message templates cannot correctly distinguish between success and failure. It is recommended to use the `when.status` condition to split notifications for success and failure, as shown below:
 
 ```yaml
 - name: discord success notification


### PR DESCRIPTION
- Add documentation note explaining that in Woodpecker 3.x, build.status is always "success", which affects message templates
- Recommend using the when.status condition to separate success and failure notifications, with example YAML provided
- Clarify that this issue results from upstream Woodpecker CI changes and is not fixable in the plugin

fix #64 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new section for Woodpecker 3.x users explaining changes to the `build.status` variable and its impact on message templates.
  * Provided guidance and example configuration for handling success and failure notifications using `when.status`.
  * Clarified that this behavior is due to changes in Woodpecker CI and must be addressed via pipeline configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->